### PR TITLE
Show one digit after the decimal point

### DIFF
--- a/src/cpu_mon.cpp
+++ b/src/cpu_mon.cpp
@@ -71,7 +71,7 @@ namespace cpu_mon {
 
         if (cfg::cpu_busy_percent)
             std::snprintf(buf, sizeof buf,
-                          "PPC0: %2.0f%%  PPC1: %2.0f%%  PPC2: %2.0f%%  ARM: %2.0f%%",
+                          "PPC0: %2.1f%%  PPC1: %2.1f%%  PPC2: %2.1f%%  ARM: %2.1f%%",
                           c0, c1, c2, c3);
         else
             std::snprintf(buf, sizeof buf,

--- a/src/gx2_mon.cpp
+++ b/src/gx2_mon.cpp
@@ -641,7 +641,7 @@ namespace gx2_mon {
             static char buf[16];
             if (cfg::gpu_busy_percent)
                 std::snprintf(buf, sizeof buf,
-                              "GPU: %2.0f%%",
+                              "GPU: %2.1f%%",
                               avg_gpu_busy);
             else
                 std::snprintf(buf, sizeof buf,
@@ -686,7 +686,7 @@ namespace gx2_mon {
             float fps = counter / dt;
             counter = 0;
 
-            std::snprintf(buf, sizeof buf, "%02.0f fps", fps);
+            std::snprintf(buf, sizeof buf, "%02.1f fps", fps);
             return buf;
         }
 


### PR DESCRIPTION
I think this looks better and is more informative:
![image](https://github.com/user-attachments/assets/e20acedd-472c-4036-ba16-c9fc71cbc4fa)
